### PR TITLE
Remove snapshot identifier from rds

### DIFF
--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -71,7 +71,7 @@ resource "aws_db_instance" "rds" {
   db_subnet_group_name   = "${aws_db_subnet_group.rds_subnet_group.id}"
   vpc_security_group_ids = ["${aws_security_group.rds_sg.id}"]
   skip_final_snapshot    = true
-  snapshot_identifier    = "rds-${var.environment}-snapshot"
+  #snapshot_identifier    = "rds-${var.environment}-snapshot"
   tags {
     Environment = "${var.environment}"
   }


### PR DESCRIPTION
closes #7 

Most of the users won't have db snapshot to create db